### PR TITLE
Bump: target-redshift 0.0.0 -> 0.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name='target-redshift',
     url='https://github.com/datamill-co/target-redshift',
     author='datamill',
-    version="0.0.0",
+    version="0.0.1",
     description='Singer.io target for loading data into redshift',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Motivation

Beginning discussion on cutting a release of `target-redshift` to PyPi.

## Suggested Musical Pairing

Windows creaking from frost