### PR TITLE
Fix/schema test isolation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,11 +104,11 @@ jobs:
             python setup.py pytest --verbose
           environment:
             REDSHIFT_PORT: 5439
+            REDSHIFT_DATABASE: 'test_target_redshift'
             TARGET_S3_BUCKET: 'test-target-redshift'
             ## Specifier in the project envvars in CCI
             #   environment:
             #     REDSHIFT_HOST='<your-host-name>' # Most likely 'localhost'
-            #     REDSHIFT_DATABASE='<your-db-name>'     # We use 'target_redshift_test'
             #     REDSHIFT_USERNAME='<your-user-name'
             #     REDSHIFT_PASSWORD='<your-password>'
             #     TARGET_S3_AWS_ACCESS_KEY_ID='<AKIA...>'

--- a/README.md
+++ b/README.md
@@ -170,7 +170,16 @@ See the [PyTest](#pytest) commands below!
 
 ### DB
 
-To run the tests, you will need an _actual_ Redshift cluster running.
+To run the tests, you will need an _actual_ Redshift cluster running, and a user that either:
+
+- Has the ability to _create_ schemas therein
+  - This is required if you wish to run multiple versions of the tests, similar
+  to how we run our [CI tests by varying the `REDSHIFT_SCHEMA` envvar](https://github.com/datamill-co/target-redshift/blob/master/.circleci/config.yml#L94-L96)
+
+- has access to the `public` schema
+  - If the `REDSHIFT_SCHEMA` is seen to be the string `"public"`, the tests will ignore creating and dropping schemas
+  - This setup is often preferred for situations in which `GRANT CREATE ON DATABASE db TO user;`
+  is viewed as too risky
 
 Make sure to set the following env vars for [PyTest](#pytest):
 

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -36,7 +36,7 @@ def main(config, input_stream=None):
         redshift_target = RedshiftTarget(
             connection,
             s3,
-            postgres_schema=config.get('redshift_schema', 'public'),
+            redshift_schema=config.get('redshift_schema', 'public'),
             logging_level=config.get('logging_level')
         )
 

--- a/target_redshift/redshift.py
+++ b/target_redshift/redshift.py
@@ -9,8 +9,6 @@ from target_postgres.singer_stream import (
 )
 from target_postgres.sql_base import SEPARATOR
 
-from target_redshift import s3
-
 
 class RedshiftError(PostgresError):
     """

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,11 +2,12 @@ import json
 import os
 import random
 
-import pytest
-import psycopg2
 import arrow
-from faker import Faker
 from chance import chance
+from faker import Faker
+import psycopg2
+from psycopg2 import sql
+import pytest
 
 CONFIG = {
     'redshift_host': os.environ['REDSHIFT_HOST'],

--- a/tests/test_target_redshift.py
+++ b/tests/test_target_redshift.py
@@ -7,8 +7,6 @@ import psycopg2.extras
 import pytest
 
 from fixtures import CatStream, CONFIG, db_cleanup, MultiTypeStream, NestedStream, TEST_DB
-from target_postgres import json_schema
-from target_postgres import postgres
 from target_postgres import singer_stream
 from target_postgres.target_tools import TargetError
 


### PR DESCRIPTION
# Motivation

Presently, `target-redshift` has two minor bugs:

- doesn't use the `redshift_schema` information passed into it
- doesn't isolate instances of tests running against the remote Redshift cluster

The first is simple to fix. The _second_ is damning because it prevents us from being able to have multiple CI or local tests running at the same time.

## Suggested Musical Pairing

https://soundcloud.com/future-islands/ran