### PR TITLE
Feature/volumes over add for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ ENV/
 
 # Singer files
 *.txt
+
+/venv--*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM python:3.7.1-stretch
-
-RUN echo 'alias pytest="python setup.py pytest"' >> ~/.bashrc
-
-ADD ./ /code
-WORKDIR /code
-RUN python setup.py develop
-
-ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ As soon as you see `INFO: Dev environment ready.` you can shell into the contain
 
 ```sh
 $ docker exec -it target-redshift_target-redshift_1 bash # Your container names might differ
+root@... $ source /code/venv--target-redshift/bin/activate
+root@... $ pytest
 ```
 
 See the [PyTest](#pytest) commands below!

--- a/README.md
+++ b/README.md
@@ -64,30 +64,30 @@ pip install target-redshift
 The fields available to be specified in the config file are specified
 here.
 
-| Field | Type | Default | Details |
-| ----- | ---- | ------- | ------- |
-| `redshift_host` |`["string"]` | `N/A` | |
-| `redshift_port` | `["integer", "null"]`|  `5432` | |
-| `redshift_database` | `["string"]`|  `N/A` | |
-| `redshift_username` | `["string"]` |  `N/A` | |
-| `redshift_password` | `["string"]`|  `N/A` | |
-| `redshift_schema` | `["string", "null"]` |  `"public"` | |
-| `invalid_records_detect` | `["boolean", "null"]`| `true` | Include `false` in your config to disable `target-redshift` from crashing on invalid records |
-| `invalid_records_threshold` | `["integer", "null"]` | `0` | Include a positive value `n` in your config to allow for `target-redshift` to encounter at most `n` invalid records per stream before giving up. |
-| `disable_collection` | `["string", "null"]` | `false` | Include `true` in your config to disable [Singer Usage Logging](#usage-logging). |
-| `logging_level` | `["string", "null"]` | `"INFO"` | The level for logging. Set to `DEBUG` to get things like queries executed, timing of those queries, etc. See [Python's Logger Levels](https://docs.python.org/3/library/logging.html#levels) for information about valid values. |
-| `persist_empty_tables` | `["boolean", "null"]` | `False` | Whether the Target should create tables which have no records present in Remote.
-| `default_column_length` | `["integer", "null"]` | `1000` | All columns with the VARCHAR(CHARACTER VARYING) type will be have this length.Range: 1-65535. |
-| `target_s3` | `["object"]` | `N/A` | See `S3` below |
+| Field                       | Type                  | Default    | Details                                                                                                                                                                                                                          |
+| --------------------------- | --------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `redshift_host`             | `["string"]`          | `N/A`      |                                                                                                                                                                                                                                  |
+| `redshift_port`             | `["integer", "null"]` | `5432`     |                                                                                                                                                                                                                                  |
+| `redshift_database`         | `["string"]`          | `N/A`      |                                                                                                                                                                                                                                  |
+| `redshift_username`         | `["string"]`          | `N/A`      |                                                                                                                                                                                                                                  |
+| `redshift_password`         | `["string"]`          | `N/A`      |                                                                                                                                                                                                                                  |
+| `redshift_schema`           | `["string", "null"]`  | `"public"` |                                                                                                                                                                                                                                  |
+| `invalid_records_detect`    | `["boolean", "null"]` | `true`     | Include `false` in your config to disable `target-redshift` from crashing on invalid records                                                                                                                                     |
+| `invalid_records_threshold` | `["integer", "null"]` | `0`        | Include a positive value `n` in your config to allow for `target-redshift` to encounter at most `n` invalid records per stream before giving up.                                                                                 |
+| `disable_collection`        | `["string", "null"]`  | `false`    | Include `true` in your config to disable [Singer Usage Logging](#usage-logging).                                                                                                                                                 |
+| `logging_level`             | `["string", "null"]`  | `"INFO"`   | The level for logging. Set to `DEBUG` to get things like queries executed, timing of those queries, etc. See [Python's Logger Levels](https://docs.python.org/3/library/logging.html#levels) for information about valid values. |
+| `persist_empty_tables`      | `["boolean", "null"]` | `False`    | Whether the Target should create tables which have no records present in Remote.                                                                                                                                                 |
+| `default_column_length`     | `["integer", "null"]` | `1000`     | All columns with the VARCHAR(CHARACTER VARYING) type will be have this length.Range: 1-65535.                                                                                                                                    |
+| `target_s3`                 | `["object"]`          | `N/A`      | See `S3` below                                                                                                                                                                                                                   |
 
 #### S3 Config.json
 
-| Field | Type | Default | Details |
-| ----- | ---- | ------- | ------- |
-| `aws_access_key_id` |`["string"]` | `N/A` | |
-| `aws_secret_access_key` |`["string"]` | `N/A` | |
-| `bucket` |`["string"]` | `N/A` | Bucket where staging files should be uploaded to. |
-| `key_prefix` |`["string", "null"]` | `""` | Prefix for staging file uploads to allow for better delineation of tmp files|
+| Field                   | Type                 | Default | Details                                                                      |
+| ----------------------- | -------------------- | ------- | ---------------------------------------------------------------------------- |
+| `aws_access_key_id`     | `["string"]`         | `N/A`   |                                                                              |
+| `aws_secret_access_key` | `["string"]`         | `N/A`   |                                                                              |
+| `bucket`                | `["string"]`         | `N/A`   | Bucket where staging files should be uploaded to.                            |
+| `key_prefix`            | `["string", "null"]` | `""`    | Prefix for staging file uploads to allow for better delineation of tmp files |
 
 ## Known Limitations
 
@@ -97,18 +97,18 @@ here.
   object, and array types with or without null are supported. Arrays can
   have any of the other types listed, including objects as types within
   items.
-    - Example of JSON Schema types that work
-        - `['number']`
-        - `['string']`
-        - `['string', 'null']`
-    - Exmaple of JSON Schema types that **DO NOT** work
-        - `['string', 'integer']`
-        - `['integer', 'number']`
-        - `['any']`
-        - `['null']`
+  - Example of JSON Schema types that work
+    - `['number']`
+    - `['string']`
+    - `['string', 'null']`
+  - Exmaple of JSON Schema types that **DO NOT** work
+    - `['string', 'integer']`
+    - `['integer', 'number']`
+    - `['any']`
+    - `['null']`
 - JSON Schema combinations such as `anyOf` and `allOf` are not supported.
-- JSON Schema $ref is partially supported:
-  - ***NOTE:*** The following limitations are known to **NOT** fail gracefully
+- JSON Schema \$ref is partially supported:
+  - **_NOTE:_** The following limitations are known to **NOT** fail gracefully
   - Presently you cannot have any circular or recursive `$ref`s
   - `$ref`s must be present within the schema:
     - URI's do not work
@@ -122,7 +122,7 @@ here.
 - Field/Column names are restricted to:
   - 127 characters in length
   - ASCII characters
-- Fields/Columns are ***ALL*** `nullable`
+- Fields/Columns are **_ALL_** `nullable`
 - Fields/Columns use a default of 1000 characters (in order to be able to work with a large number of columns).
 
 ## Usage Logging
@@ -177,13 +177,14 @@ See the [PyTest](#pytest) commands below!
 To run the tests, you will need an _actual_ Redshift cluster running, and a user that either:
 
 - Has the ability to _create_ schemas therein
+
   - This is required if you wish to run multiple versions of the tests, similar
-  to how we run our [CI tests by varying the `REDSHIFT_SCHEMA` envvar](https://github.com/datamill-co/target-redshift/blob/master/.circleci/config.yml#L94-L96)
+    to how we run our [CI tests by varying the `REDSHIFT_SCHEMA` envvar](https://github.com/datamill-co/target-redshift/blob/master/.circleci/config.yml#L94-L96)
 
 - has access to the `public` schema
   - If the `REDSHIFT_SCHEMA` is seen to be the string `"public"`, the tests will ignore creating and dropping schemas
   - This setup is often preferred for situations in which `GRANT CREATE ON DATABASE db TO user;`
-  is viewed as too risky
+    is viewed as too risky
 
 Make sure to set the following env vars for [PyTest](#pytest):
 
@@ -230,5 +231,6 @@ Target Redshift is sponsored by Data Mill (Data Mill Services, LLC) [datamill.co
 
 Data Mill helps organizations utilize modern data infrastructure and data science to power analytics, products, and services.
 
-------
+---
+
 Copyright Data Mill Services, LLC 2018

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '2'
 services:
   target-redshift:
-    build:
-      context: .
-      dockerfile: ./Dockerfile
+    image: python:3.7.1-stretch
+    working_dir: /code
+    entrypoint: /code/docker-entrypoint.sh
     environment:
       REDSHIFT_HOST: "${REDSHIFT_HOST}"
       REDSHIFT_DATABASE: "${REDSHIFT_DATABASE}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
+python -m venv venv--target-redshift
+source /code/venv--target-redshift/bin/activate
+
+pip install -e .
+
 echo -e "\n\nINFO: Dev environment ready."
+
 tail -f /dev/null


### PR DESCRIPTION
# Motivation

Recently reached some understanding of Docker and `VOLUME` vs `ADD`. Since my local memory keeps filling up with random containers, this change seemed useful.

Effectively, allow Docker Compose to mount the necessary development volumes, instead of adding them to the container themselves...

This has made the number of containers I have locally drop asymptotically.

## Suggested Musical Pairing

https://soundcloud.com/uffie-official-458383245/papercuts-2