### PR TITLE
Allow STS token to be used as a config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ here.
 | ----------------------- | -------------------- | ------- | ---------------------------------------------------------------------------- |
 | `aws_access_key_id`     | `["string"]`         | `N/A`   |                                                                              |
 | `aws_secret_access_key` | `["string"]`         | `N/A`   |                                                                              |
+| `aws_session_token`     | `["string"]`         | `N/A`   | STS session token if using temporary credentials                             |
 | `bucket`                | `["string"]`         | `N/A`   | Bucket where staging files should be uploaded to.                            |
 | `key_prefix`            | `["string", "null"]` | `""`    | Prefix for staging file uploads to allow for better delineation of tmp files |
 

--- a/target_redshift/__init__.py
+++ b/target_redshift/__init__.py
@@ -31,7 +31,8 @@ def main(config, input_stream=None):
         s3 = S3(s3_config.get('aws_access_key_id'),
                 s3_config.get('aws_secret_access_key'),
                 s3_config.get('bucket'),
-                s3_config.get('key_prefix'))
+                s3_config.get('key_prefix'),
+                aws_session_token=s3_config.get('aws_session_token'))
 
         redshift_target = RedshiftTarget(
             connection,

--- a/target_redshift/s3.py
+++ b/target_redshift/s3.py
@@ -6,13 +6,22 @@ SEPARATOR = '__'
 
 
 class S3:
-    def __init__(self, aws_access_key_id, aws_secret_access_key, bucket, key_prefix=''):
+    def __init__(
+        self,
+        aws_access_key_id,
+        aws_secret_access_key,
+        bucket,
+        key_prefix='',
+        aws_session_token=None
+    ):
         self._credentials = {'aws_access_key_id': aws_access_key_id,
-                             'aws_secret_access_key': aws_secret_access_key}
+                             'aws_secret_access_key': aws_secret_access_key,
+                             'aws_session_token': aws_session_token}
         self.client = boto3.client(
             's3',
             aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key)
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token)
         self.bucket = bucket
         self.key_prefix = key_prefix
 


### PR DESCRIPTION
This allows a workaround for temporary credential usage, allowing workarounds when using roles.

The example use case here is using Apache Airflow: I wish to use the built in credentials providers which airflow uses - to do this I'm using IAM roles which are assumed by boto3 automatically, and then taking the access key/secret key/sts token and providing them to libraries which need them.

It'd be equally useful to allow an AWS profile or role to be used in future, specifically to separate the role used by Redshift COPY and the S3 credentials to do the multipart upload.