### PR TITLE
Enhance: add more granular metrics logging to s3 persist and copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ ENV/
 *.txt
 
 /venv--*
+.idea

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
     install_requires=[
         'boto3>=1.9.205,<1.10.0',
         'singer-target-postgres==0.2.1',
-        'urllib3==1.25.6'
+        'urllib3==1.25.6',
+        'smart-open==1.9.0'
     ],
     setup_requires=[
         "pytest-runner"

--- a/target_redshift/redshift.py
+++ b/target_redshift/redshift.py
@@ -141,7 +141,7 @@ class RedshiftTarget(PostgresTarget):
                     credentials.get('aws_access_key_id'),
                     credentials.get('aws_secret_access_key'))),
                 sql.Literal(RESERVED_NULL_DEFAULT),
-                sql.Literal("GZIP")
+                "GZIP"
             )
 
             cur.execute(copy_sql)

--- a/target_redshift/redshift.py
+++ b/target_redshift/redshift.py
@@ -132,7 +132,7 @@ class RedshiftTarget(PostgresTarget):
         credentials = self.s3.credentials()
 
         with self._set_timer_tags(metrics.job_timer(), 's3_copy', (remote_schema['name'],)):
-            copy_sql = sql.SQL('COPY {}.{} ({}) FROM {} CREDENTIALS {} FORMAT AS CSV NULL AS {}').format(
+            copy_sql = sql.SQL('COPY {}.{} ({}) FROM {} CREDENTIALS {} FORMAT AS CSV NULL AS {} {}').format(
                 sql.Identifier(self.postgres_schema),
                 sql.Identifier(temp_table_name),
                 sql.SQL(', ').join(map(sql.Identifier, columns)),
@@ -140,7 +140,9 @@ class RedshiftTarget(PostgresTarget):
                 sql.Literal('aws_access_key_id={};aws_secret_access_key={}'.format(
                     credentials.get('aws_access_key_id'),
                     credentials.get('aws_secret_access_key'))),
-                sql.Literal(RESERVED_NULL_DEFAULT))
+                sql.Literal(RESERVED_NULL_DEFAULT),
+                sql.Literal("GZIP")
+            )
 
             cur.execute(copy_sql)
 

--- a/target_redshift/redshift.py
+++ b/target_redshift/redshift.py
@@ -132,7 +132,7 @@ class RedshiftTarget(PostgresTarget):
         credentials = self.s3.credentials()
 
         with self._set_timer_tags(metrics.job_timer(), 's3_copy', (remote_schema['name'],)):
-            copy_sql = sql.SQL('COPY {}.{} ({}) FROM {} CREDENTIALS {} FORMAT AS CSV NULL AS {} {}').format(
+            copy_sql = sql.SQL('COPY {}.{} ({}) FROM {} CREDENTIALS {} FORMAT AS CSV NULL AS {} GZIP').format(
                 sql.Identifier(self.postgres_schema),
                 sql.Identifier(temp_table_name),
                 sql.SQL(', ').join(map(sql.Identifier, columns)),
@@ -141,7 +141,6 @@ class RedshiftTarget(PostgresTarget):
                     credentials.get('aws_access_key_id'),
                     credentials.get('aws_secret_access_key'))),
                 sql.Literal(RESERVED_NULL_DEFAULT),
-                "GZIP"
             )
 
             cur.execute(copy_sql)

--- a/target_redshift/s3.py
+++ b/target_redshift/s3.py
@@ -21,9 +21,9 @@ class S3:
         return self._credentials
 
     def persist(self, readable, key_prefix=''):
-        key = self.key_prefix + key_prefix + str(uuid.uuid4()).replace('-', '')
+        key = self.key_prefix + key_prefix + str(uuid.uuid4()).replace('-', '') + ".gz"
 
-        with open("s3://{}/{}".format(self.bucket, key), 'wb', transport_params=self.transport_params) as s3_fo:
+        with open("s3://{}/{}".format(self.bucket, key), 'w', transport_params=self.transport_params) as s3_fo:
             s3_fo.write(readable.read())
 
         return [self.bucket, key]


### PR DESCRIPTION
Thanks for target-redshift. For observability we'd really appreciate having more granular metrics around the S3 upload and copy operations if possible. This should be a lightweight enhancement that doesn't create too much extra noise.

- Adds `s3_persist` metric logging around upload of records to s3.
- Adds `s3_copy` metric logging around copy command from s3 to redshift.